### PR TITLE
meshop memory optimizations

### DIFF
--- a/geometry/CMakeLists.txt
+++ b/geometry/CMakeLists.txt
@@ -104,7 +104,7 @@ else()
 endif()
 
 define_module(LIBRARY geometry=${geometry_VERSION}
-  DEPENDS math>=1.8 utility>=1.11 dbglog>=1.4
+  DEPENDS math>=1.8 utility>=1.35 dbglog>=1.4
   ${geometry_EXTRA_DEPENDS}
   DEFINITIONS ${geometry_EXTRA_DEFINITIONS})
 

--- a/geometry/meshop.cpp
+++ b/geometry/meshop.cpp
@@ -38,6 +38,7 @@
 #include "triclip.hpp"
 
 #include "utility/expect.hpp"
+#include "utility/small_list.hpp"
 
 #include <set>
 #include <boost/numeric/ublas/vector.hpp>
@@ -480,7 +481,7 @@ Mesh::pointer removeNonManifoldEdges(Mesh omesh)
     };
 
     struct Edge {
-        std::set<index_type> facesIndices;
+        utility::small_list<index_type, 2> facesIndices;
     };
 
     //count faces for each edge
@@ -505,14 +506,13 @@ Mesh::pointer removeNonManifoldEdges(Mesh omesh)
         }
     }
 
-
     //collect faces incident with non-manifold edge
     std::set<index_type> facesToOmit;
     for(auto it = edgeMap.begin(); it!=edgeMap.end(); it++){
         if(it->second.facesIndices.size()>2){
-            for(const auto & fi : it->second.facesIndices){
+            it->second.facesIndices.for_each([&](index_type fi) {
                 facesToOmit.insert(fi);
-            }
+            });
         }
     }
 

--- a/geometry/meshop.hpp
+++ b/geometry/meshop.hpp
@@ -225,7 +225,7 @@ Mesh::pointer refine( const Mesh &mesh, unsigned int maxFacesCount);
  * \param mesh mesh to process
  * \return processed mesh
  */
-Mesh::pointer removeNonManifoldEdges( const Mesh& omesh );
+Mesh::pointer removeNonManifoldEdges(Mesh omesh);
 
 /** Removes isolated vertices, e.g vertices incidental with 0 faces
  * Works with untextured meshes


### PR DESCRIPTION
Reduced peak memory usage.
- used `std::move` on mesh where possible to avoid creating temporary copies
- `removeNonManifoldEdges` now takes mesh by value, since it's being duplicated anyway and this way we can `std::move` the mesh to the function
- `std::size_t` is unnecessarily large type for vertex indices; changed to `Face::index_type`
- storing `std::set` per mesh edge is terribly inefficient; changed to `utility::small_list<index_type, 2>`, since normally every edge is incident to at most 2 faces
