### PR TITLE
Fixing zero search radius in point normals estimation

### DIFF
--- a/geometry/estimate-point-normals.hpp
+++ b/geometry/estimate-point-normals.hpp
@@ -143,8 +143,9 @@ std::vector<T> estimateNormals(const std::vector<T>& pointCloud,
         if (radius <= 0.0) {
             // Mode 2: search radius is variable and is based on the average
             // radius needed to reach the specified number of neighbors
-            searchRadius
-                = (pointsProcessed ? (searchRadiusTotal / pointsProcessed) : 1.0);
+            searchRadius = ((searchRadiusTotal && pointsProcessed)
+                                ? (searchRadiusTotal / pointsProcessed)
+                                : 1.0);
             ++pointsProcessed;
         }
 


### PR DESCRIPTION
I observed that on some pointclouds during normal estimation, the function gets stuck in an infinite loop.

I tracked down the problem to `searchRadius` being set to `0` here:
https://github.com/melowntech/libgeometry/blob/003c58cf92e46ac01d506987f47b770929cc799b/geometry/estimate-point-normals.hpp#L146-L147

It is set to zero in the second iteration of the for cycle ([line 136](https://github.com/melowntech/libgeometry/blob/003c58cf92e46ac01d506987f47b770929cc799b/geometry/estimate-point-normals.hpp#L136)). It seems that in some configurations, `collectNeighbors()` returns `0` (presumably because of duplicate points?), which causes the `searchRadius` to be set to `0` in the next iteration.

When `searchRadius == 0`, the cycle in `collectNeighbors()` gets stuck in an infinite loop.

This simple fix prevents the situation.