### PR TITLE
Fix crash in removeIsolatedVertices if there are no texture coords.

### DIFF
--- a/geometry/meshop.cpp
+++ b/geometry/meshop.cpp
@@ -627,11 +627,11 @@ Mesh::pointer removeIsolatedVertices( const Mesh& imesh ){
     std::map<math::Points3::size_type, math::Points3::size_type> vertexMap;
     std::map<math::Points2::size_type, math::Points2::size_type> tCoordsMap;
 
-    for( const auto& face: imesh.faces ){
+    for (const auto& face: imesh.faces) {
         math::Points3::size_type vindices[3] { face.a , face.b, face.c };
         math::Points2::size_type tindices[3] { face.ta , face.tb, face.tc };
 
-        for(unsigned int i=0; i<3; ++i){
+        for (unsigned int i = 0; i < 3; ++i) {
             auto vit = vertexMap.find(vindices[i]);
             auto tit = tCoordsMap.find(tindices[i]);
 
@@ -639,13 +639,15 @@ Mesh::pointer removeIsolatedVertices( const Mesh& imesh ){
                 mesh.vertices.push_back(imesh.vertices[vindices[i]]);
                 vit = vertexMap.insert(std::make_pair(vindices[i],mesh.vertices.size()-1)).first;
             }
-            if(imesh.tCoords.size() > 0 && tit == tCoordsMap.end()){
-                mesh.tCoords.push_back(imesh.vertices[tindices[i]]);
-                tit = tCoordsMap.insert(std::make_pair(tindices[i],mesh.tCoords.size()-1)).first;
-            }
-
             vindices[i] = vit->second;
-            tindices[i] = tit->second;
+
+            if (imesh.tCoords.size() > 0) {
+                if (tit == tCoordsMap.end()) {
+                    mesh.tCoords.push_back(imesh.vertices[tindices[i]]);
+                    tit = tCoordsMap.insert(std::make_pair(tindices[i],mesh.tCoords.size()-1)).first;
+                }
+                tindices[i] = tit->second;
+            }
         }
 
         if(imesh.tCoords.size() > 0){

--- a/geometry/meshop.cpp
+++ b/geometry/meshop.cpp
@@ -620,28 +620,31 @@ Mesh::pointer removeNonManifoldEdges(Mesh omesh)
     return pmesh;
 }
 
-Mesh::pointer removeIsolatedVertices( const Mesh& imesh ){
+Mesh::pointer removeIsolatedVertices( const Mesh& imesh )
+{
     auto pmesh(std::make_shared<geometry::Mesh>());
     auto & mesh(*pmesh);
 
     std::map<math::Points3::size_type, math::Points3::size_type> vertexMap;
     std::map<math::Points2::size_type, math::Points2::size_type> tCoordsMap;
 
+    bool hasTexture = (imesh.tCoords.size() > 0);
+
     for (const auto& face: imesh.faces) {
         math::Points3::size_type vindices[3] { face.a , face.b, face.c };
         math::Points2::size_type tindices[3] { face.ta , face.tb, face.tc };
 
         for (unsigned int i = 0; i < 3; ++i) {
-            auto vit = vertexMap.find(vindices[i]);
-            auto tit = tCoordsMap.find(tindices[i]);
 
-            if(vit == vertexMap.end()){
+            auto vit = vertexMap.find(vindices[i]);
+            if (vit == vertexMap.end()) {
                 mesh.vertices.push_back(imesh.vertices[vindices[i]]);
                 vit = vertexMap.insert(std::make_pair(vindices[i],mesh.vertices.size()-1)).first;
             }
             vindices[i] = vit->second;
 
-            if (imesh.tCoords.size() > 0) {
+            if (hasTexture) {
+                auto tit = tCoordsMap.find(tindices[i]);
                 if (tit == tCoordsMap.end()) {
                     mesh.tCoords.push_back(imesh.vertices[tindices[i]]);
                     tit = tCoordsMap.insert(std::make_pair(tindices[i],mesh.tCoords.size()-1)).first;
@@ -650,11 +653,11 @@ Mesh::pointer removeIsolatedVertices( const Mesh& imesh ){
             }
         }
 
-        if(imesh.tCoords.size() > 0){
+        if (hasTexture ){
             mesh.addFace( vindices[0], vindices[1], vindices[2]
                         , tindices[0], tindices[1], tindices[2] );
         }
-        else{
+        else {
             mesh.addFace( vindices[0], vindices[1], vindices[2] );
         }
     }


### PR DESCRIPTION
The 'tit' iterator then points to map.end() and cannot be used.

The crash only occurs in a Windows debug build (as far as I know).
