### PR TITLE
Add mesh polygonization and getFaceFaceTableNonManifold()

### DIFF
--- a/geometry/CMakeLists.txt
+++ b/geometry/CMakeLists.txt
@@ -12,6 +12,7 @@ if (OPENMESH_FOUND)
 
   set(geometry_OPENMESH_SOURCES
     meshop-openmesh.cpp
+    mesh-polygonization.cpp
     )
 
   # handle() is deprecated -> no warning
@@ -140,6 +141,8 @@ set(geometry_SOURCES
   multipolymesh.hpp multipolymesh.cpp
 
   parse-ply.cpp parse-ply.hpp
+
+  mesh-polygonization.hpp
 
   ${geometry_OPENMESH_SOURCES}
   ${geometry_CGAL_SOURCES}

--- a/geometry/mesh-polygonization.cpp
+++ b/geometry/mesh-polygonization.cpp
@@ -353,6 +353,14 @@ std::tuple<std::vector<VhMpolyFace>, std::vector<int>>
     // check all halfedges
     for (const auto& hehStart : pmesh.halfedges())
     {
+        // skip halfedge with no face to the left
+        if (!hehStart.is_valid()) { continue; }
+        if (hehStart.is_boundary())
+        {
+            LOG(warn2) << "Mesh is not watertight";
+            continue;
+        }
+
         // skip non-boundary
         if (!isBoundaryHalfedge(pmesh, hehStart, faceRegionProp)) { continue; }
         // skip traversed

--- a/geometry/mesh-polygonization.cpp
+++ b/geometry/mesh-polygonization.cpp
@@ -466,6 +466,10 @@ MultiPolyMesh<int> polygonizeMesh(const Mesh& mesh,
         auto b { pVertices[mesh.faces[i].b] };
         auto c { pVertices[mesh.faces[i].c] };
         auto fh { pmesh.add_face(a, b, c) };
+        if (!fh.is_valid())
+        {
+            LOGTHROW(err4, std::runtime_error) << "Unable to add face";
+        }
         pmesh.property(faceRegionProp, fh) = faceRegions[i];
     }
 

--- a/geometry/mesh-polygonization.cpp
+++ b/geometry/mesh-polygonization.cpp
@@ -1,0 +1,467 @@
+/**
+ * Copyright (c) 2023 Melown Technologies SE
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *  Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mesh-polygonization.hpp"
+
+#include <queue>
+#include <cmath>
+#include <map>
+
+#include "math/math.hpp"
+#include "math/geometry.hpp"
+#include "utility/small_set.hpp"
+
+#include "polygon.hpp"
+
+namespace geometry
+{
+
+namespace
+{
+
+/// Multipolygonal face (i.e. polygonal face with holes) with vertices in pmesh
+using VhMpolyFace = std::vector<std::vector<OMPolyMesh::VertexHandle>>;
+
+inline math::Point3 fromOM(const OMPolyMesh::Point& p)
+{
+    return math::Point3(p[0], p[1], p[2]);
+}
+
+inline bool isFinite(const OMPolyMesh::Normal& n)
+{
+    return std::isfinite(n[0]) && std::isfinite(n[1]) && std::isfinite(n[2]);
+}
+
+
+/// Returns true if the halfedge is on region boundary. Optionally checks for
+/// specific left region.
+inline bool isBoundaryHalfedge(const OMPolyMesh& pmesh,
+                               const OMPolyMesh::HalfedgeHandle& heh,
+                               const OMFacePropInt& faceRegionProp,
+                               int checkLeftRegion = -1)
+{
+    auto leftR { pmesh.property(faceRegionProp, pmesh.face_handle(heh)) };
+    if (checkLeftRegion >= 0)
+    {
+        if (leftR != checkLeftRegion) { return false; }
+    }
+
+    auto op { pmesh.opposite_halfedge_handle(heh) };
+    if (pmesh.is_boundary(op))
+    {
+        LOG(warn2) << "Mesh is not watertight.";
+        return true;
+    }
+    auto rightR { pmesh.property(faceRegionProp, pmesh.face_handle(op)) };
+    return leftR != rightR;
+}
+
+/// Returns true if the vertex is adjacent to more than two regions
+inline bool isImportantVertex(const OMPolyMesh& pmesh,
+                              const OMPolyMesh::VertexHandle& vh,
+                              const OMFacePropInt& faceRegionProp)
+{
+    int r1 { -1 };
+    int r2 { -1 };
+
+    // circulate around the current vertex
+    for (auto vfit = pmesh.cvf_iter(vh); vfit.is_valid(); ++vfit)
+    {
+        int region = pmesh.property(faceRegionProp, *vfit);
+        if (region == r1 || region == r2) { continue; }
+        if (r1 == -1)
+        {
+            r1 = region;
+            continue;
+        }
+        if (r2 == -1)
+        {
+            r2 = region;
+            continue;
+        }
+        return true;
+    }
+    return false;
+}
+
+/// Find the next halfedge that points to a face of the same region
+inline OMPolyMesh::HalfedgeHandle
+    getNextRegionHalfedge(const OMPolyMesh& pmesh,
+                          const OMPolyMesh::HalfedgeHandle& hehPrev,
+                          const OMFacePropInt& faceRegionProp,
+                          bool searchCCW = false)
+{
+    auto rIdx { pmesh.property(faceRegionProp, pmesh.face_handle(hehPrev)) };
+
+    // iterate over outcoming edges
+    auto hehStart { pmesh.next_halfedge_handle(hehPrev) };
+    if (searchCCW)
+    {
+        hehStart = pmesh.opposite_halfedge_handle(pmesh.prev_halfedge_handle(
+            pmesh.opposite_halfedge_handle(hehPrev)));
+    }
+
+    auto heh { hehStart };
+    do
+    {
+        if (isBoundaryHalfedge(pmesh, heh, faceRegionProp, rIdx))
+        {
+            return heh;
+        }
+
+        if (!searchCCW)
+        {
+            heh = pmesh.next_halfedge_handle(
+                pmesh.opposite_halfedge_handle(heh));
+        }
+        else
+        {
+            heh = pmesh.opposite_halfedge_handle(
+                pmesh.prev_halfedge_handle(heh));
+        }
+    }
+    while (heh != hehStart);
+
+    LOGTHROW(err4, std::runtime_error)
+        << "Cannot find the next halfedge on the region boundary (something is "
+           "very wrong).";
+    throw;
+}
+
+/// Traverse a region boundary, recording vertices and adding visited halfedges
+/// to `visitedHalfedges`. Check for
+void traverseRegionBoundary(
+    const OMPolyMesh& pmesh,
+    const OMPolyMesh::HalfedgeHandle& hehStart,
+    const OMFacePropInt& faceRegionProp,
+    std::vector<std::vector<OMPolyMesh::VertexHandle>>& boundaryVertices,
+    utility::small_set<OMPolyMesh::HalfedgeHandle>& visitedHalfedges,
+    bool knownIsInnerBoundary = false)
+{
+    utility::small_set<OMPolyMesh::VertexHandle> visitedVertices;
+    auto heh { hehStart };
+
+    auto duplicateVertex { false };
+    std::vector<OMPolyMesh::VertexHandle> boundary; // add new boundary
+    do
+    {
+        visitedHalfedges.insert(heh);
+        auto v { pmesh.from_vertex_handle(heh) };
+
+        if (visitedVertices.count(v))
+        {
+            // visiting same vertex twice - holes meeting at vertex
+            duplicateVertex = true;
+            break;
+        }
+
+        visitedVertices.insert(v);
+        if (isImportantVertex(pmesh, v, faceRegionProp))
+        {
+            boundary.push_back(v);
+        }
+        heh = getNextRegionHalfedge(pmesh,
+                                    heh,
+                                    faceRegionProp,
+                                    knownIsInnerBoundary);
+    }
+    while (heh != hehStart);
+
+    if (duplicateVertex && knownIsInnerBoundary)
+    {
+        LOGTHROW(err4, std::runtime_error)
+            << "Encountering duplicate vertex when traversing known inner "
+               "boundary";
+    }
+
+    if (duplicateVertex)
+    {
+        // restart traversal from all outgoing edges of the duplicate vertex
+        auto v { pmesh.from_vertex_handle(heh) };
+        auto rIdx { pmesh.property(faceRegionProp,
+                                   pmesh.face_handle(hehStart)) };
+
+        for (auto it { pmesh.cvoh_begin(v) }; it.is_valid(); ++it)
+        {
+            if (!isBoundaryHalfedge(pmesh, *it, faceRegionProp, rIdx))
+            {
+                continue;
+            }
+            traverseRegionBoundary(pmesh,
+                                   *it,
+                                   faceRegionProp,
+                                   boundaryVertices,
+                                   visitedHalfedges,
+                                   true);
+        }
+    }
+    else
+    {
+        boundaryVertices.push_back(std::move(boundary));
+    }
+}
+
+/// Returns area of polygon defined by vertices of `boundary` transformed to 2D
+/// by `tf`.
+double boundaryArea(const std::vector<OMPolyMesh::VertexHandle>& boundary,
+                    const OMPolyMesh& pmesh,
+                    const math::Matrix4& glob2plane)
+{
+    math::Points2 pts;
+    pts.reserve(boundary.size());
+    for (const auto& v : boundary)
+    {
+        math::Point3 pt3(math::transform(glob2plane, fromOM(pmesh.point(v))));
+        pts.emplace_back(pt3(0), pt3(1));
+    }
+    return geometry::area(pts);
+}
+
+/// Traverse connected faces of one region and create a multipolygonal face
+VhMpolyFace traverseConnectedFacesOfRegion(
+    const OMPolyMesh::HalfedgeHandle& hehStart,
+    const math::Matrix4& glob2plane,
+    const OMPolyMesh& pmesh,
+    const OMFacePropInt& faceRegionProp,
+    utility::small_set<OMPolyMesh::HalfedgeHandle>& traversedHalfedges)
+{
+    // get main info
+    int rIdx = pmesh.property(faceRegionProp, pmesh.face_handle(hehStart));
+
+    // Traverse whole connected component of the region
+    utility::small_set<OMPolyMesh::HalfedgeHandle> enqueuedHalfedges;
+    std::queue<OMPolyMesh::HalfedgeHandle> halfedgeQ;
+    halfedgeQ.push(hehStart);
+    enqueuedHalfedges.insert(hehStart);
+
+    int outerBoundaryNum { 0 };
+    VhMpolyFace multipolygon;
+
+    while (!halfedgeQ.empty())
+    {
+        auto heh { halfedgeQ.front() };
+        halfedgeQ.pop();
+
+        // if boundary halfedge, traverse the boundary
+        if (isBoundaryHalfedge(pmesh, heh, faceRegionProp)
+            && !traversedHalfedges.count(heh))
+        {
+            std::vector<std::vector<OMPolyMesh::VertexHandle>> foundBoundaries;
+
+            traverseRegionBoundary(pmesh,
+                                   heh,
+                                   faceRegionProp,
+                                   foundBoundaries,
+                                   traversedHalfedges);
+
+            for (auto& boundary : foundBoundaries)
+            {
+                // check if its inner or outer boundary
+                if (boundaryArea(boundary, pmesh, glob2plane) > 0)
+                {
+                    ++outerBoundaryNum;
+                    multipolygon.insert(multipolygon.begin(),
+                                        std::move(boundary));
+                }
+                else
+                {
+                    multipolygon.push_back(std::move(boundary));
+                }
+            }
+        }
+
+        // Check all next halfedges in cw direction
+        auto neighboursStart { pmesh.next_halfedge_handle(heh) };
+        auto neighbour { neighboursStart };
+        do
+        {
+            if (pmesh.property(faceRegionProp, pmesh.face_handle(neighbour))
+                != rIdx)
+            {
+                break; // exit if not in region
+            }
+            if (!enqueuedHalfedges.count(neighbour))
+            {
+                halfedgeQ.push(neighbour);
+                enqueuedHalfedges.insert(neighbour);
+            }
+
+            neighbour = pmesh.next_halfedge_handle(
+                pmesh.opposite_halfedge_handle(neighbour));
+        }
+        while (neighbour != neighboursStart);
+    }
+
+    if (outerBoundaryNum != 1)
+    {
+        LOGTHROW(err4, std::runtime_error)
+            << "Expecting exactly one outer boundary, got: "
+            << outerBoundaryNum;
+    }
+    return multipolygon;
+}
+
+/// Create a transformation to 2D coordinates of the face plane
+inline math::Matrix4 getGlobal2FacePlane(const OMPolyMesh& pmesh,
+                                         const OMPolyMesh::HalfedgeHandle& heh)
+{
+
+    auto n { pmesh.calc_face_normal(pmesh.face_handle(heh)) };
+    if (!isFinite(n))
+    {
+        LOGTHROW(err4, std::runtime_error)
+            << "Got inf/nan face normal - mesh might contain zero-area faces";
+    }
+    auto pt { fromOM(pmesh.point(pmesh.from_vertex_handle(heh))) };
+    math::Plane3 pl(pt, math::Point3(n[0], n[1], n[2]));
+    return math::matrixInvert(math::createPlaneCrs(pl));
+}
+
+
+/// Create multipolygonal faces consisting of connected faces of one region
+std::tuple<std::vector<VhMpolyFace>, std::vector<int>>
+    getMultiPolygonalFaces(const OMPolyMesh& pmesh,
+                           const OMFacePropInt& faceRegionProp)
+{
+    std::vector<VhMpolyFace> mpolyFaces;
+    std::vector<int> mpolyFacesRegions;
+
+    utility::small_set<OMPolyMesh::HalfedgeHandle> traversedHalfedges;
+    // check all halfedges
+    for (const auto& hehStart : pmesh.halfedges())
+    {
+        // skip non-boundary
+        if (!isBoundaryHalfedge(pmesh, hehStart, faceRegionProp)) { continue; }
+        // skip traversed
+        if (traversedHalfedges.count(hehStart)) { continue; }
+
+        auto glob2plane { getGlobal2FacePlane(pmesh, hehStart) };
+
+        mpolyFaces.push_back(
+            traverseConnectedFacesOfRegion(hehStart,
+                                           glob2plane,
+                                           pmesh,
+                                           faceRegionProp,
+                                           traversedHalfedges));
+        mpolyFacesRegions.push_back(
+            pmesh.property(faceRegionProp, pmesh.face_handle(hehStart)));
+    }
+
+    return std::make_tuple(std::move(mpolyFaces), std::move(mpolyFacesRegions));
+}
+
+/// Construct multipolygonal mesh based on multipolygonal faces defined by
+/// vertex handles in pmesh
+MultiPolyMesh<int> createMultiPolyMesh(const OMPolyMesh& pmesh,
+                                       const std::vector<VhMpolyFace>& mpFaces,
+                                       const std::vector<int>& mpFaceRegions)
+{
+    MultiPolyMesh<int> omesh;
+    std::map<OMPolyMesh::VertexHandle, std::size_t> vertexMap;
+
+    // add all used vertices
+    for (const auto& mpFace : mpFaces)
+    {
+        for (const auto& poly : mpFace)
+        {
+            for (const auto& v : poly)
+            {
+                if (vertexMap.count(v)) { continue; }
+                auto vIdx { omesh.vertices.size() };
+                omesh.vertices.push_back(fromOM(pmesh.point(v)));
+                vertexMap[v] = vIdx;
+            }
+        }
+    }
+
+    // add all faces
+    omesh.faces.reserve(mpFaces.size());
+    for (size_t i = 0; i < mpFaces.size(); i++)
+    {
+        auto& mpFace { mpFaces[i] };
+        geometry::MultiPolyFace face;
+        for (const auto& vhPoly : mpFace)
+        {
+            std::vector<std::size_t> poly;
+            for (const auto& v : vhPoly)
+            {
+                poly.push_back(vertexMap.at(v));
+            }
+            face.push_back(std::move(poly));
+        }
+        omesh.faces.push_back(std::move(face));
+        omesh.faceLabels.push_back(mpFaceRegions[i]);
+    }
+
+    return omesh;
+}
+
+
+} // namespace
+
+MultiPolyMesh<int> polygonizeMesh(const OMPolyMesh& mesh,
+                                  const OMFacePropInt& faceRegions)
+{
+    auto [mpFaces, mpRegions] = getMultiPolygonalFaces(mesh, faceRegions);
+    return createMultiPolyMesh(mesh, mpFaces, mpRegions);
+}
+
+
+MultiPolyMesh<int> polygonizeMesh(const Mesh& mesh,
+                                  const std::vector<int>& faceRegions)
+{
+    if (faceRegions.size() != mesh.faces.size())
+    {
+        LOGTHROW(err4, std::runtime_error)
+            << "Face regions contains " << faceRegions.size()
+            << " items while the mesh has " << mesh.faces.size() << " faces.";
+    }
+
+    // convert to openmesh & add property
+    OMPolyMesh pmesh;
+    OMFacePropInt faceRegionProp;
+    pmesh.add_property(faceRegionProp);
+
+    std::vector<OMPolyMesh::VertexHandle> pVertices(mesh.vertices.size());
+    for (size_t i = 0; i < mesh.vertices.size(); i++)
+    {
+        auto& p { mesh.vertices[i] };
+        pVertices[i] = pmesh.add_vertex(OMPolyMesh::Point(p(0), p(1), p(2)));
+    }
+
+    for (size_t i = 0; i < mesh.faces.size(); i++)
+    {
+        auto a { pVertices[mesh.faces[i].a] };
+        auto b { pVertices[mesh.faces[i].b] };
+        auto c { pVertices[mesh.faces[i].c] };
+        auto fh { pmesh.add_face(a, b, c) };
+        pmesh.property(faceRegionProp, fh) = faceRegions[i];
+    }
+
+    return polygonizeMesh(pmesh, faceRegionProp);
+}
+
+} // namespace geometry

--- a/geometry/mesh-polygonization.hpp
+++ b/geometry/mesh-polygonization.hpp
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2023 Melown Technologies SE
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *  Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file mesh-polygonization.hpp
+ * @author Tomas Novak <tomas.novak@melowntech.com>
+ *
+ * Convert triangular mesh to polygonal mesh.
+ */
+
+#ifndef GEOMETRY_MESH_POLYGONIZATION_HPP_INCLUDED_
+#define GEOMETRY_MESH_POLYGONIZATION_HPP_INCLUDED_
+
+#include <stddef.h>
+#include <vector>
+
+#include "dbglog/dbglog.hpp"
+#include "utility/gccversion.hpp"
+
+#include "mesh.hpp"
+#include "multipolymesh.hpp"
+
+#ifdef GEOMETRY_HAS_OPENMESH
+#    include <OpenMesh/Core/Mesh/PolyMesh_ArrayKernelT.hh>
+#endif
+
+
+namespace geometry
+{
+
+#ifdef GEOMETRY_HAS_OPENMESH
+
+struct OMPolyMeshTraits : public OpenMesh::DefaultTraits
+{
+    using Point = OpenMesh::Vec3d; // doubles
+    FaceAttributes(
+        OpenMesh::Attributes::Color
+        | OpenMesh::Attributes::Status); // face colors, allow removing faces
+    EdgeAttributes(OpenMesh::Attributes::Status); // allow removing edges
+    VertexAttributes(OpenMesh::Attributes::Status);
+    HalfedgeAttributes(OpenMesh::Attributes::PrevHalfedge);
+};
+
+/**
+ * OpenMesh mesh with polygonal faces
+ */
+using OMPolyMesh = OpenMesh::PolyMesh_ArrayKernelT<OMPolyMeshTraits>;
+using OMFacePropInt = OpenMesh::FPropHandleT<int>;
+
+MultiPolyMesh<int> polygonizeMesh(const OMPolyMesh& mesh,
+                                  const OMFacePropInt& faceRegions);
+
+#endif // #ifdef GEOMETRY_HAS_OPENMESH
+
+
+/**
+ * Merge regions of triangles to polygons (with holes).
+ *
+ * Works on watertight 2-manifolds. Mesh must have correct topology. On errors,
+ * check for zero-area faces, non-manifold edges, duplicite vertices, ...
+ *
+ * NB: OpenMesh is required
+ *
+ * @param[in] mesh
+ * @param[in] faceRegions region index for each face
+ * @returns resulting multipolygonal mesh
+ */
+MultiPolyMesh<int> polygonizeMesh(const Mesh& mesh,
+                                  const std::vector<int>& faceRegions)
+#ifndef GEOMETRY_HAS_OPENMESH
+        UTILITY_FUNCTION_ERROR(
+            "Mesh polygonization is available only when compiled with "
+            "OpenMesh.")
+#endif
+    ;
+
+} // namespace geometry
+
+
+#endif /* GEOMETRY_MESH_POLYGONIZATION_HPP_INCLUDED_ */

--- a/geometry/mesh-polygonization.hpp
+++ b/geometry/mesh-polygonization.hpp
@@ -79,8 +79,12 @@ MultiPolyMesh<int> polygonizeMesh(const OMPolyMesh& mesh,
 /**
  * Merge regions of triangles to polygons (with holes).
  *
- * Works on watertight 2-manifolds. Mesh must have correct topology. On errors,
- * check for zero-area faces, non-manifold edges, duplicite vertices, ...
+ * Works on well-oriented 2-manifolds. Mesh must have correct topology. On
+ * errors, check for zero-area faces, non-manifold edges, duplicite vertices,
+ * etc...
+ *
+ * The face regions must lead to correct topology (each region is adjacent 
+ * to >2 other regions or mesh borders).
  *
  * NB: OpenMesh is required
  *

--- a/geometry/meshop.cpp
+++ b/geometry/meshop.cpp
@@ -41,7 +41,6 @@
 #include "triclip.hpp"
 
 #include "utility/expect.hpp"
-#include "utility/small_list.hpp"
 
 #include <set>
 #include <boost/algorithm/string.hpp>
@@ -372,7 +371,7 @@ Mesh loadPly(const boost::filesystem::path& filepath)
     return simpleParser.mesh;
 }
 
-const unsigned int imageIdLimit(1<<16);
+const unsigned int imageIdLimit { 1 << 16 };
 
 void loadObj( ObjParserBase &parser
             , const boost::filesystem::path &filename)
@@ -547,65 +546,68 @@ Mesh clip(const Mesh &omesh, const math::Extents3 &extents)
     return out;
 }
 
+namespace
+{
+
+template <typename T>
+struct EdgeKeyTmpl
+{
+    T v1_, v2_; // vertex indices
+
+    EdgeKeyTmpl(T v1, T v2)
+    {
+        v1_ = std::min(v1, v2);
+        v2_ = std::max(v1, v2);
+    }
+
+    bool operator<(const EdgeKeyTmpl& other) const
+    {
+        return (v1_ == other.v1_) ? (v2_ < other.v2_) : (v1_ < other.v1_);
+    }
+};
+
+using EdgeKey = EdgeKeyTmpl<Face::index_type>;
+using NonManifoldEdge = boost::container::small_vector<Face::index_type, 2>;
+using EdgeMap = std::map<EdgeKey, NonManifoldEdge>;
+
+/// Creates map edge->faces, supports non-manifold edges (>2 incident faces)
+EdgeMap getNonManifoldEdgeMap(const Mesh& mesh)
+{
+    EdgeMap edgeMap;
+    for (std::size_t i = 0; i < mesh.faces.size(); i++)
+    {
+        auto& f = mesh.faces[i];
+        edgeMap[EdgeKey(f.a, f.b)].push_back(i);
+        edgeMap[EdgeKey(f.b, f.c)].push_back(i);
+        edgeMap[EdgeKey(f.c, f.a)].push_back(i);
+    }
+    return edgeMap;
+}
+
+} // namespace
+
 Mesh::pointer removeNonManifoldEdges(Mesh omesh)
 {
+    auto edgeMap { getNonManifoldEdgeMap(omesh) };
+
     auto ofaces = omesh.faces;
     auto pmesh(std::make_shared<geometry::Mesh>(std::move(omesh)));
     auto& mesh(*pmesh);
     mesh.faces.clear();
     mesh.faces.shrink_to_fit();
 
-    typedef Face::index_type index_type;
+    using index_type = Face::index_type;
 
-    struct EdgeKey
-    {
-        index_type v1, v2; // vertex indices
-
-        EdgeKey(index_type v1, index_type v2)
-        {
-            this->v1 = std::min(v1, v2);
-            this->v2 = std::max(v1, v2);
-        }
-
-        bool operator< (const EdgeKey& other) const
-        {
-            return (v1 == other.v1) ? (v2 < other.v2) : (v1 < other.v1);
-        }
-    };
-
-    struct Edge {
-        utility::small_list<index_type, 2> facesIndices;
-    };
-
-    //count faces for each edge
-    std::map<EdgeKey,Edge> edgeMap;
-    for(index_type fi=0; fi<ofaces.size(); fi++){
-        const auto & face(ofaces[fi]);
-        EdgeKey edgeKeys[3] = { EdgeKey(face.a,face.b)
-                           , EdgeKey(face.b,face.c)
-                           , EdgeKey(face.c,face.a) };
-        for(const auto & key : edgeKeys){
-            auto it = edgeMap.find(key);
-            if(it==edgeMap.end()){
-                //if edge is not present insert it with current face
-                Edge edge;
-                edge.facesIndices.insert(fi);
-                edgeMap.insert(std::make_pair(key,edge));
-            }
-            else{
-                //if edge is present add current face to it
-                it->second.facesIndices.insert(fi);
-            }
-        }
-    }
-
-    //collect faces incident with non-manifold edge
+    // collect faces incident with non-manifold edge
     std::set<index_type> facesToOmit;
-    for(auto it = edgeMap.begin(); it!=edgeMap.end(); it++){
-        if(it->second.facesIndices.size()>2){
-            it->second.facesIndices.for_each([&](index_type fi) {
+    for (auto& edge : edgeMap)
+    {
+        if (edge.second.size() > 2)
+        {
+            for (auto& fi : edge.second)
+            {
                 facesToOmit.insert(fi);
-            });
+            }
         }
     }
 
@@ -618,6 +620,34 @@ Mesh::pointer removeNonManifoldEdges(Mesh omesh)
     }
 
     return pmesh;
+}
+
+FaceFaceTable getFaceFaceTableNonManifold(const Mesh& mesh)
+{
+    auto edgeMap { getNonManifoldEdgeMap(mesh) };
+
+    FaceFaceTable ffTable;
+    ffTable.resize(mesh.faces.size());
+
+    // collect neighbours across each edge of a face
+    for (std::size_t fI = 0; fI < mesh.faces.size(); fI++)
+    {
+        auto& face { mesh.faces[fI] };
+
+        std::array<EdgeKey, 3> triEdges = { EdgeKey(face.a, face.b),
+                                            EdgeKey(face.b, face.c),
+                                            EdgeKey(face.c, face.a) };
+        for (const auto& e : triEdges)
+        {
+            for (const auto& n : edgeMap.at(e))
+            {
+                if (n == fI) { continue; }
+                ffTable[fI].push_back(n);
+            }
+        }
+    }
+
+    return ffTable;
 }
 
 Mesh::pointer removeIsolatedVertices( const Mesh& imesh ){
@@ -666,21 +696,7 @@ Mesh::pointer refine( const Mesh & omesh, unsigned int maxFacesCount)
     auto pmesh(std::make_shared<geometry::Mesh>(omesh));
     auto & mesh(*pmesh);
 
-    struct EdgeKey
-    {
-        std::size_t v1, v2; // vertex indices
-
-        EdgeKey(std::size_t v1, std::size_t v2)
-        {
-            this->v1 = std::min(v1, v2);
-            this->v2 = std::max(v1, v2);
-        }
-
-        bool operator< (const EdgeKey& other) const
-        {
-            return (v1 == other.v1) ? (v2 < other.v2) : (v1 < other.v1);
-        }
-    };
+    using EdgeKeyST = EdgeKeyTmpl<std::size_t>;
 
     struct Edge {
         typedef enum {
@@ -720,7 +736,7 @@ Mesh::pointer refine( const Mesh & omesh, unsigned int maxFacesCount)
     };
 
     struct EdgeMap {
-        std::map<EdgeKey, std::shared_ptr<Edge>> map;
+        std::map<EdgeKeyST, std::shared_ptr<Edge>> map;
         std::vector<std::shared_ptr<Edge>> heap;
 
         bool compareEdgePtr(const std::shared_ptr<Edge> &a, const std::shared_ptr<Edge> &b){
@@ -730,7 +746,7 @@ Mesh::pointer refine( const Mesh & omesh, unsigned int maxFacesCount)
         void addFaceEdge(std::size_t pv1, std::size_t pv2, int fid
                          , Edge::EdgeType type, float length)
         {
-            EdgeKey key(pv1, pv2);
+            EdgeKeyST key(pv1, pv2);
             auto it(map.find(key));
             if(it!=map.end()){
                 it->second->addFace(pv1, pv2, fid, type );
@@ -753,7 +769,7 @@ Mesh::pointer refine( const Mesh & omesh, unsigned int maxFacesCount)
                 return this->compareEdgePtr(a,b);
             });
             heap.pop_back();
-            map.erase(EdgeKey(edge.v1, edge.v2));
+            map.erase(EdgeKeyST(edge.v1, edge.v2));
             return edge;
         }
 

--- a/geometry/meshop.hpp
+++ b/geometry/meshop.hpp
@@ -236,11 +236,11 @@ using FaceFaceTable = std::vector<boost::container::small_vector<std::size_t, 3>
 /** Computes face incidency map, supports non manifold edges (face may have >3
  * neighbors).
  *
- * NB: when two faces are incident over multiple edges, they are repated
+ * NB: when two faces are incident over multiple edges, they are repeated
  * respective amount of times
  *
  * @param[in] mesh mesh to process
- * @returns face incicency table
+ * @returns face incidency table
  */
 FaceFaceTable getFaceFaceTableNonManifold(const Mesh& mesh);
 

--- a/geometry/meshop.hpp
+++ b/geometry/meshop.hpp
@@ -36,6 +36,7 @@
 #include <iostream>
 
 #include <boost/optional.hpp>
+#include <boost/container/small_vector.hpp>
 
 #include "utility/gccversion.hpp"
 
@@ -226,6 +227,22 @@ Mesh::pointer refine( const Mesh &mesh, unsigned int maxFacesCount);
  * \return processed mesh
  */
 Mesh::pointer removeNonManifoldEdges(Mesh omesh);
+
+/**
+ * Face incidency - for each face lists all neighbors, supports non-manifolds
+ */
+using FaceFaceTable = std::vector<boost::container::small_vector<std::size_t, 3>>;
+
+/** Computes face incidency map, supports non manifold edges (face may have >3
+ * neighbors).
+ *
+ * NB: when two faces are incident over multiple edges, they are repated
+ * respective amount of times
+ *
+ * @param[in] mesh mesh to process
+ * @returns face incicency table
+ */
+FaceFaceTable getFaceFaceTableNonManifold(const Mesh& mesh);
 
 /** Removes isolated vertices, e.g vertices incidental with 0 faces
  * Works with untextured meshes

--- a/geometry/multipolymesh.hpp
+++ b/geometry/multipolymesh.hpp
@@ -34,11 +34,13 @@
 #ifndef geometry_multipolymesh_hpp_included_
 #define geometry_multipolymesh_hpp_included_
 
-#include "geometry/mesh.hpp"
-#include "geometry/multipolygon-triangulate-gts.hpp"
-#include "geometry/polygon.hpp"
 #include "math/geometry_core.hpp"
 #include "math/transform.hpp"
+
+#include "mesh.hpp"
+#include "meshop.hpp"
+#include "multipolygon-triangulate-gts.hpp"
+#include "polygon.hpp"
 
 namespace geometry
 {
@@ -153,6 +155,24 @@ struct MultiPolyMesh
     Mesh triangulateFaces(std::vector<FaceLabels>* const triFaceLabels
                           = nullptr) const;
 };
+
+
+/**
+ * Save mulipolygonal mesh as obj file
+ *
+ * Non-negative face labels indicate the index of material.
+ * NB: holes in polygons are omitted
+ *
+ * @param[in] mesh
+ * @param[in] filepath
+ * @param[in] mtl
+ * @param[in] streamSetup function to setup output stream
+ */
+void saveAsObj(const MultiPolyMesh<int>& mesh,
+               const boost::filesystem::path& filepath,
+               const ObjMaterial& mtl,
+               const std::function<bool(std::ostream&)>& streamSetup);
+
 
 // Implementation following
 


### PR DESCRIPTION
- Mesh polygonization `polygonizeMesh()` - merges triangles in one region to polygons and creates polygonal mesh
- `saveAsObj()` for `MultiPolyMesh`
- `getFaceFaceTableNonManifold()` - separate function to get face adjacency map for non-manifolds - implied refactor of `removeNonManifoldEdges()`